### PR TITLE
Account move import improvements

### DIFF
--- a/account_move_base_import/parser/parser.py
+++ b/account_move_base_import/parser/parser.py
@@ -48,6 +48,7 @@ class AccountMoveImportParser(object):
         self.move_date = None
         self.move_name = None
         self.move_ref = None
+        self.support_multi_moves = None
 
     @classmethod
     def parser_for(cls, parser_name):
@@ -147,10 +148,16 @@ class AccountMoveImportParser(object):
             raise Exception(_('No buffer file given.'))
         self._format(*args, **kwargs)
         self._pre(*args, **kwargs)
-        self._parse(*args, **kwargs)
-        self._validate(*args, **kwargs)
-        self._post(*args, **kwargs)
-        yield self.result_row_list
+        if self.support_multi_moves:
+            while self._parse(*args, **kwargs):
+                self._validate(*args, **kwargs)
+                self._post(*args, **kwargs)
+                yield self.result_row_list
+        else:
+            self._parse(*args, **kwargs)
+            self._validate(*args, **kwargs)
+            self._post(*args, **kwargs)
+            yield self.result_row_list
 
 
 def itersubclasses(cls, _seen=None):

--- a/account_move_base_import/tests/test_base_import.py
+++ b/account_move_base_import/tests/test_base_import.py
@@ -34,6 +34,7 @@ class TestCodaImport(common.TransactionCase):
             'partner_id': self.partner.id,
             'commission_account_id': self.account_id,
             'receivable_account_id': self.account_id,
+            'create_counterpart': True,
         })
 
     def _filename_to_abs_filename(self, file_name):

--- a/account_move_base_import/views/journal_view.xml
+++ b/account_move_base_import/views/journal_view.xml
@@ -22,6 +22,8 @@
                         <field name="commission_account_id"/>
                         <field name="receivable_account_id" attrs="{'required': [('used_for_import', '=', True)]}"/>
                         <field name="partner_id"/>
+                        <field name="create_counterpart"/>
+                        <field name="split_counterpart" attrs="{'invisible': [('create_counterpart', '=', False)]}"/>
                     </group>
                     <group>
                         <button name="%(account_move_base_import.move_importer_action)d"


### PR DESCRIPTION
Hello Matthieu,
I made some improvement I talked about in your PR in OCA.
I think it would be great to merge it in your branch. Then I guess it will be good from my side.

I added 2 things : 
- Multi move creation from 1 file. It just add very few lines of code, coming from v7 module account_statement_base_completion
- Add an option to create the counter part line, so we do not need to implement it in each parser.
  (Another option if we want to split this counterpart line, in case of refund for example.)

I also added an onchange to fill the counterpart option automatically for the existing generic parsers.

Let me know if it is ok,
Thanks
