### PR TITLE
invalidate cache after move sql insert

### DIFF
--- a/account_move_base_import/models/account_journal.py
+++ b/account_move_base_import/models/account_journal.py
@@ -303,6 +303,7 @@ class AccountJournal(models.Model):
                 move_store.append(values)
             # Hack to bypass ORM poor perfomance. Sob...
             move_line_obj._insert_lines(move_store)
+            self.env.invalidate_all()
             self._write_extra_move_lines(parser, move)
             if self.create_counterpart:
                 self._create_counterpart(parser, move)


### PR DESCRIPTION
I am testing with another import type, which does not add commission line.
We have to invalidate the cache after the INSERT sql query, else move.line_ids is empty.
I did not see the problem with the generic import because of the commission line creation, which invalidate the cache already.
